### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.fastcampusprojectboard.repository;
 
 import com.fastcampus.fastcampusprojectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment,Long> {
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.fastcampusprojectboard.repository;
 
 import com.fastcampus.fastcampusprojectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,13 +30,13 @@ spring:
       hibernate.default_batch_fetch_size: 100
       #
   sql.init.mode: always
-#  data.rest:
-#    base-path: /api
-#    detection-strategy: annotated
-#  thymeleaf3.decoupled-logic: true
   h2:
     console:
       enabled: false
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
+#  thymeleaf3.decoupled-logic: true
 
 ---
 

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/controller/DataRestTest.java
@@ -1,0 +1,105 @@
+package com.fastcampus.fastcampusprojectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+//@WebMvcTest
+@Transactional
+@DisplayName("Data Rest - API 테스트")
+@AutoConfigureMockMvc // SpringBootTest만으로는 MovcMvc 테스트를 감지할 수 없어 AutoconfigureMockmvc Annotation을 달아줘서 감지하게함.
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+//                .andDo(print());
+//        존재하는 경로이지만 404 Error가 나오면서 테스트 검증이 실패함. 웹 mvc 테스트는 슬라이스 테스트임 컨트롤러 웨 빌드를 로드하지 않는다.
+//        컨트롤러와 연관된것들 최소한을 로드함. 이 테스트를 인테그레이션으로 바꾸는 방법이 존재함.
+//        아래와 같이 이 테스트를 진행하면 쿼리도 같이 나오는데 이건 디비에 영향을 주는 것을 보여주므로 @Trensactional 을 추가하여 영향을 최소한을 하자
+//        select
+//        article0_.id as id1_0_,
+//                article0_.created_at as created_2_0_,
+//        article0_.created_by as created_3_0_,
+//                article0_.modified_at as modified4_0_,
+//        article0_.modified_by as modified5_0_,
+//                article0_.content as content6_0_,
+//        article0_.hashtag as hashtag7_0_,
+//                article0_.title as title8_0_
+//        from
+//        article article0_ limit ?
+//                Hibernate:
+//                select
+//        count(article0_.id) as col_0_0_
+//        from
+//        article article0_
+    }
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스하고, 해당 api들의 존재 여부만 체크하게 끔 통합테스트 작성

